### PR TITLE
Adds support for v1 compatible binary names in the bundler

### DIFF
--- a/crates/tauri-bundler/Cargo.toml
+++ b/crates/tauri-bundler/Cargo.toml
@@ -62,7 +62,6 @@ tauri-macos-sign = { version = "0.1.1-rc.0", path = "../tauri-macos-sign" }
 [target."cfg(any(target_os = \"macos\", target_os = \"windows\"))".dependencies]
 regex = "1"
 
-[target."cfg(target_os = \"linux\")".dependencies]
 heck = "0.5"
 ar = "0.9.0"
 md5 = "0.7.0"

--- a/crates/tauri-bundler/src/bundle/common.rs
+++ b/crates/tauri-bundler/src/bundle/common.rs
@@ -3,14 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use anyhow::Context;
+use heck::ToKebabCase;
 use std::{
   ffi::OsStr,
   fs::{self, File},
   io::{self, BufRead, BufReader, BufWriter},
-  path::Path,
+  path::{Path, PathBuf},
   process::{Command, ExitStatus, Output, Stdio},
   sync::{Arc, Mutex},
 };
+use tauri_utils::display_path;
 
 /// Returns true if the path has a filename indicating that it is a high-density
 /// "retina" icon.  Specifically, returns true the file stem ends with
@@ -124,6 +127,44 @@ pub fn copy_dir(from: &Path, to: &Path) -> crate::Result<()> {
     }
   }
   Ok(())
+}
+
+pub(crate) fn use_v1_bin_name() -> bool {
+  let env_var = std::env::var("V1_COMPATIBLE_BIN_NAME");
+  env_var.as_deref() == Ok("true") || env_var.as_deref() == Ok("1")
+}
+
+pub(crate) fn rename_app(
+  target: &str,
+  bin_path: &Path,
+  product_name: &str,
+) -> crate::Result<PathBuf> {
+  let target_os = target
+    .split('-')
+    .nth(2)
+    .unwrap_or(std::env::consts::OS)
+    .replace("darwin", "macos");
+
+  let product_name = if target_os == "linux" {
+    product_name.to_kebab_case()
+  } else {
+    product_name.into()
+  };
+
+  let product_path = bin_path
+    .parent()
+    .unwrap()
+    .join(product_name)
+    .with_extension(bin_path.extension().unwrap_or_default());
+
+  fs::rename(bin_path, &product_path).with_context(|| {
+    format!(
+      "failed to rename `{}` to `{}`",
+      display_path(bin_path),
+      display_path(&product_path),
+    )
+  })?;
+  Ok(product_path)
 }
 
 /// Copies user-defined files specified in the configuration file to the package.

--- a/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
+++ b/crates/tauri-cli/ENVIRONMENT_VARIABLES.md
@@ -37,6 +37,7 @@ These environment variables are inputs to the CLI which may have an equivalent C
 - `TAURI_WEBVIEW_AUTOMATION` — Enables webview automation (Linux Only).
 - `TAURI_ANDROID_PROJECT_PATH` — Path of the tauri android project, usually will be `<project>/src-tauri/gen/android`.
 - `TAURI_IOS_PROJECT_PATH` — Path of the tauri iOS project, usually will be `<project>/src-tauri/gen/ios`.
+- `V1_COMPATIBLE_BIN_NAME` — If set, the CLI will rename the main app binary to the `productName`, as it did in Tauri v1. This is useful for allowing users of a Tauri v1 app to update the app to a v2 version via the updater.
 
 ### Tauri CLI Hook Commands
 


### PR DESCRIPTION
🚧 ~~Work in progress~~ abandoned 🚧
👉 This task was picked up in https://github.com/tauri-apps/tauri/pull/10938

This allows users of a Tauri v1 application to be able to smoothly update to a Tauri v2 application via the updater.

## Background: 
This change in Tauri https://github.com/tauri-apps/tauri/pull/9375/files, which is noted as a refactor is in fact a breaking change as far as the app updater is concerned. 

The impact is that because the binary now has a different name, it is not possible to smoothly update a Tauri application via the updater if the initial version of the app is using `v1.x` and the new version is using `v2.x`.

## Related upstream issues
https://github.com/tauri-apps/tauri/issues/10548
https://github.com/tauri-apps/tauri-docs/issues/2523 (docs)

## Approach:
I'm introducing here an option for the `tauri-cli` (`tauri-bundler`) for producing the same binary names it did in `v1`, allowing users to update the app via the updater. In order to enable this behavior, set the environment varible
```
V1_COMPATIBLE_BIN_NAME=true
```
Previously, the bundler did the rename just after building the binary. I poked and tried doing the same once again, but because quite a lot of the code in that bundler changed since that was merged, it felt possibly more error prone (since now the rest of the code can safely assume that the binary is the crate name)

So, instead, my approach is to do the rename the binary at the last moment (i.e. in the `bundle_project` function in eg. app.rs)

## Steps:
- [x] Introduce an env variable to enable the v1 behavior
- [ ] Support the v1 renaming behavior for:
- [x] MacOS
- [ ] Windows MSI
- [ ] Windows NSIS
- [ ] Debian
- [ ] Fedora
- [ ] AppImage
- [ ] Tests?